### PR TITLE
Fix rendering issue in Subset Sum page by adjusting inline LaTeX syntax for T[i,j]

### DIFF
--- a/materials/algorithms/dp/ss/index.qmd
+++ b/materials/algorithms/dp/ss/index.qmd
@@ -28,7 +28,7 @@ Let us try to project this problem on a prefix of the input array and a generic 
 
 For $1 \leq i \leq n$ and $1 \leq j \leq Y$, let:
 
-$T[i,j] = $ TRUE if some subset of $X[1,\ldots,i]$ sums to $j$, and FALSE otherwise.
+$T[i,j] =$ TRUE if some subset of $X[1,\ldots,i]$ sums to $j$, and FALSE otherwise.
 
 The $T$-values are our fragments.
 :::


### PR DESCRIPTION
# Fix Rendering Issue in Subset Sum Page

## Description

This PR addresses a rendering issue in the Quarto page caused by incorrect inline LaTeX syntax. Specifically, the expression `$T[i,j] = $ TRUE` was causing the problem. The issue has been resolved by adjusting the LaTeX syntax to ensure proper rendering.

## Changes Made

- Corrected the inline LaTeX syntax from `$T[i,j] = $ TRUE` to `$T[i,j] =$ TRUE`.

## Impact

- Fixes the rendering issue for the specific equation, ensuring the Quarto page displays the content correctly. See the images below to see the difference:
Before:
![Screenshot from 2024-06-19 10-24-30](https://github.com/neeldhara/quartosite/assets/49206873/fe55ffd2-498a-4ee4-a8ef-8975d1e996ca)
After:
![Screenshot from 2024-06-19 10-24-14](https://github.com/neeldhara/quartosite/assets/49206873/6d0ed3ce-fef0-4be4-9c71-b053d0f435dc)


Please review and merge the changes to fix the rendering issue.